### PR TITLE
fix: link to options page broken in firefox

### DIFF
--- a/src/popup/index.ts
+++ b/src/popup/index.ts
@@ -1,6 +1,7 @@
 import './index.css';
 
 const themeSelectElement = document.querySelector('select#theme-select') as HTMLSelectElement;
+const optionsLink = `<a class="options-link" href="${chrome.runtime.getURL('options.html')}" target=”_blank”>options page</a>`;
 
 const createOptions = (defaultThemes: string[], selectedTheme: string) => {
   defaultThemes.forEach((defaultTheme) => {
@@ -17,7 +18,6 @@ const createOptions = (defaultThemes: string[], selectedTheme: string) => {
 const createMoreThemesInfo = () => {
   const linkWrapper = document.querySelector('.options-link-wrapper');
 
-  const optionsLink = `<a class="options-link" href="chrome-extension://${chrome.runtime.id}/options.html" target=”_blank”>options page</a>`;
   const themesLocationInfoElement = document.createElement('div');
   themesLocationInfoElement.innerHTML = `More themes available in the ${optionsLink}!`;
 
@@ -52,8 +52,7 @@ chrome.storage.sync.get(['defaultThemes', 'selectedTheme'], (result) => {
   // TODO add better styles
   if (defaultThemes.length === 0) {
     const mainElement = document.querySelector('main') as HTMLBaseElement;
-    mainElement.textContent =
-      "No themes selected - right click on the extention and click 'Options' to choose default themes";
+    mainElement.innerHTML = `No themes selected - go to ${optionsLink} to choose default themes`;
     mainElement.classList.add('no-theme-warning');
   }
 


### PR DESCRIPTION
Fixes 2 issues on Firefox:
- Link to options page is hard-coded as `chrome-extension://...`
	<img width="879" height="84" alt="cropped" src="https://github.com/user-attachments/assets/81461d1a-7880-475d-b302-f1f7e45451d1" />

- When no theme selected, popup says `right click on the extention and click 'Options'` but this button is in another place on Firefox
	<img width="326" height="345" alt="no-options" src="https://github.com/user-attachments/assets/709f4422-761f-41c4-b99a-75f55ff7a88b" />

